### PR TITLE
Docs/add better and more component docs and examples

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -10,9 +10,14 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/senna/senna.js",
-  "files": ["dist/", "loader/"],
+  "files": [
+    "dist/",
+    "loader/"
+  ],
   "scripts": {
     "build": "stencil build --docs",
+    "docs:json": "stencil build --docs-json",
+    "docs": "npm run build && npm run docs:json",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -8,6 +8,12 @@ import {
 } from "@stencil/core";
 import { Color } from "../../interface";
 
+/**
+ * Docs page options
+ * @docsCodePen { "user": "casaper", "id": "MWeKZmM" }
+ * @docsMenu { "group": "app" }
+ */
+
 @Component({
   tag: "sen-alert",
   styleUrl: "alert.scss",
@@ -27,6 +33,9 @@ export class Alert implements ComponentInterface {
     this.hasTitleSlot = !!this.el.querySelector('[slot="title"]');
   }
 
+  /**
+   * @slot title - optional alert title slot
+   */
   render() {
     const classes = {
       ["alert-" + this.color]: true,

--- a/core/src/components/alert/readme.md
+++ b/core/src/components/alert/readme.md
@@ -3,6 +3,30 @@
 <!-- Auto Generated Below -->
 
 
+## Usage
+
+### Danger
+
+```html
+<sen-alert color="danger">
+  Some dangerous alert text.
+</sen-alert>
+```
+
+
+### Title
+
+```html
+<sen-alert color="info">
+  <span slot="title">
+    Warning
+  </span>
+  Some warning text text.
+</sen-alert>
+```
+
+
+
 ## Properties
 
 | Property | Attribute | Description    | Type                                                                          | Default     |

--- a/core/src/components/alert/usage/danger.md
+++ b/core/src/components/alert/usage/danger.md
@@ -1,0 +1,5 @@
+```html
+<sen-alert color="danger">
+  Some dangerous alert text.
+</sen-alert>
+```

--- a/core/src/components/alert/usage/title.md
+++ b/core/src/components/alert/usage/title.md
@@ -1,0 +1,8 @@
+```html
+<sen-alert color="info">
+  <span slot="title">
+    Warning
+  </span>
+  Some warning text text.
+</sen-alert>
+```

--- a/core/src/components/button-group/button-group.scss
+++ b/core/src/components/button-group/button-group.scss
@@ -1,11 +1,20 @@
 :host {
+  /**
+  * @prop --buttons-border-radius: Border radius of button group - default `3px`
+  */
+  --buttons-border-radius: #{$btn-border-radius};
   display: flex;
 }
 
-::slotted(sen-button:first-child) {
+::slotted(sen-button) {
+  --border-left-radius: 0;
   --border-right-radius: 0;
 }
 
+::slotted(sen-button:first-child) {
+  --border-left-radius: var(--buttons-border-radius);
+}
+
 ::slotted(sen-button:last-child) {
-  --border-left-radius: 0;
+  --border-right-radius: var(--buttons-border-radius);
 }

--- a/core/src/components/button-group/button-group.stories.tsx
+++ b/core/src/components/button-group/button-group.stories.tsx
@@ -8,3 +8,12 @@ export const Default = () => `
     <sen-button color="secondary">Button 2</sen-button>
   </sen-button-group>
 `;
+
+
+export const ThreeButtons = () => `
+  <sen-button-group>
+    <sen-button color="primary">Button 1</sen-button>
+    <sen-button color="secondary">Button 2</sen-button>
+    <sen-button>Button 3</sen-button>
+  </sen-button-group>
+`;

--- a/core/src/components/button-group/button-group.tsx
+++ b/core/src/components/button-group/button-group.tsx
@@ -1,5 +1,9 @@
 import { Component, ComponentInterface, Host, h } from "@stencil/core";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "xxOZQqB" }
+ * @docsMenu { "group": "buttons" }
+ */
 @Component({
   tag: "sen-button-group",
   styleUrl: "button-group.scss",

--- a/core/src/components/button-group/readme.md
+++ b/core/src/components/button-group/readme.md
@@ -3,6 +3,27 @@
 <!-- Auto Generated Below -->
 
 
+## Usage
+
+### Examples
+
+```html
+<sen-button-group>
+  <sen-button color="primary">Button 1</sen-button>
+  <sen-button color="secondary">Button 2</sen-button>
+  <sen-button>Button 3</sen-button>
+</sen-button-group>
+```
+
+
+
+## CSS Custom Properties
+
+| Name                      | Description                                   |
+| ------------------------- | --------------------------------------------- |
+| `--buttons-border-radius` | Border radius of button group - default `3px` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/button-group/usage/examples.md
+++ b/core/src/components/button-group/usage/examples.md
@@ -1,0 +1,7 @@
+```html
+<sen-button-group>
+  <sen-button color="primary">Button 1</sen-button>
+  <sen-button color="secondary">Button 2</sen-button>
+  <sen-button>Button 3</sen-button>
+</sen-button-group>
+```

--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -1,6 +1,12 @@
 :host {
   display: inline-block;
+  /**
+  * @prop --border-left-radius: Border radius of left bottom and top edge - default `3px`
+  */
   --border-left-radius: #{$btn-border-radius};
+  /**
+  * @prop --border-right-radius: Border radius of right bottom and top edge - default `3px`
+  */
   --border-right-radius: #{$btn-border-radius};
 
   button {

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -1,6 +1,10 @@
 import { Component, ComponentInterface, Host, h, Prop } from "@stencil/core";
 import { Color } from "../../interface";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "abZdpJx" }
+ * @docsMenu { "group": "buttons" }
+ */
 @Component({
   tag: "sen-button",
   styleUrl: "button.scss",

--- a/core/src/components/button/readme.md
+++ b/core/src/components/button/readme.md
@@ -1,12 +1,20 @@
 # sen-button
 
-<p class="codepen" data-height="309" data-theme-id="dark" data-default-tab="html,result" data-user="casaper" data-slug-hash="bGpXKWx" style="height: 309px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Senna-UI Button Example">
-  <span><a href="https://codepen.io/casaper/pen/bGpXKWx">
-  Senna-UI Button Example on CodePen</a> </span>
-</p>
-<script async src="https://static.codepen.io/assets/embed/ei.js"></script>
-
 <!-- Auto Generated Below -->
+
+
+## Usage
+
+### Examples
+
+```html
+<sen-button>Default</sen-button>
+
+<sen-button color="primary">Primary</sen-button>
+
+<sen-button color="primary" disabled>Primary</sen-button>
+```
+
 
 
 ## Properties
@@ -16,6 +24,14 @@
 | `buttonType` | `button-type` | Button type         | `"button" \| "reset" \| "submit"`                                             | `"button"`  |
 | `color`      | `color`       | Button variant      | `"danger" \| "primary" \| "secondary" \| "success" \| "warning" \| undefined` | `undefined` |
 | `disabled`   | `disabled`    | Disables the button | `boolean`                                                                     | `false`     |
+
+
+## CSS Custom Properties
+
+| Name                    | Description                                                |
+| ----------------------- | ---------------------------------------------------------- |
+| `--border-left-radius`  | Border radius of left bottom and top edge - default `3px`  |
+| `--border-right-radius` | Border radius of right bottom and top edge - default `3px` |
 
 
 ----------------------------------------------

--- a/core/src/components/button/usage/examples.md
+++ b/core/src/components/button/usage/examples.md
@@ -1,0 +1,8 @@
+
+```html
+<sen-button>Default</sen-button>
+
+<sen-button color="primary">Primary</sen-button>
+
+<sen-button color="primary" disabled>Primary</sen-button>
+```

--- a/core/src/components/card-actions/card-actions.tsx
+++ b/core/src/components/card-actions/card-actions.tsx
@@ -1,5 +1,9 @@
 import { Component, ComponentInterface, Host, h } from "@stencil/core";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "LYZGXeP" }
+ * @docsMenu { "group": "layout", "subGroup": "card" }
+ */
 @Component({
   tag: "sen-card-actions",
   styleUrl: "card-actions.scss",

--- a/core/src/components/card-actions/readme.md
+++ b/core/src/components/card-actions/readme.md
@@ -1,8 +1,20 @@
 # sen-card-actions
-
-
-
 <!-- Auto Generated Below -->
+
+
+## Usage
+
+### Example
+
+```html
+<sen-card>
+  <sen-card-actions>
+    <sen-button>A button 1</sen-button>
+    <sen-button>A button 2</sen-button>
+  </sen-card-actions>
+</sen-card>
+```
+
 
 
 ----------------------------------------------

--- a/core/src/components/card-actions/usage/example.md
+++ b/core/src/components/card-actions/usage/example.md
@@ -1,0 +1,8 @@
+```html
+<sen-card>
+  <sen-card-actions>
+    <sen-button>A button 1</sen-button>
+    <sen-button>A button 2</sen-button>
+  </sen-card-actions>
+</sen-card>
+```

--- a/core/src/components/card-body/card-body.tsx
+++ b/core/src/components/card-body/card-body.tsx
@@ -1,5 +1,9 @@
 import { Component, ComponentInterface, Host, h } from "@stencil/core";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "LYZGXeP" }
+ * @docsMenu { "group": "layout", "subGroup": "card" }
+ */
 @Component({
   tag: "sen-card-body",
   styleUrl: "card-body.scss",

--- a/core/src/components/card-body/readme.md
+++ b/core/src/components/card-body/readme.md
@@ -1,8 +1,19 @@
 # sen-card-body
-
-
-
 <!-- Auto Generated Below -->
+
+
+## Usage
+
+### Example
+
+```html
+<sen-card>
+  <sen-card-body>
+    Some card body content
+  </sen-card-body>
+</sen-card>
+```
+
 
 
 ----------------------------------------------

--- a/core/src/components/card-body/usage/example.md
+++ b/core/src/components/card-body/usage/example.md
@@ -1,0 +1,7 @@
+```html
+<sen-card>
+  <sen-card-body>
+    Some card body content
+  </sen-card-body>
+</sen-card>
+```

--- a/core/src/components/card-title/card-title.tsx
+++ b/core/src/components/card-title/card-title.tsx
@@ -1,5 +1,9 @@
 import { Component, ComponentInterface, Host, h } from "@stencil/core";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "LYZGXeP" }
+ * @docsMenu { "group": "layout", "subGroup": "card" }
+ */
 @Component({
   tag: "sen-card-title",
   styleUrl: "card-title.scss",

--- a/core/src/components/card-title/readme.md
+++ b/core/src/components/card-title/readme.md
@@ -6,6 +6,20 @@
 <!-- Auto Generated Below -->
 
 
+## Usage
+
+### Example
+
+```html
+<sen-card>
+  <sen-card-title>
+    Card tryout title
+  </sen-card-title>
+</sen-card>
+```
+
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/card-title/usage/example.md
+++ b/core/src/components/card-title/usage/example.md
@@ -1,0 +1,7 @@
+```html
+<sen-card>
+  <sen-card-title>
+    Card tryout title
+  </sen-card-title>
+</sen-card>
+```

--- a/core/src/components/card/card.scss
+++ b/core/src/components/card/card.scss
@@ -2,9 +2,21 @@
 // --------------------------------------------------
 
 :host {
+  /**
+  * @prop --card-border-color: The outer border color - default `#DEDCDC`
+  */
   --card-border-color: #{$border-color};
+  /**
+  * @prop --card-border-radius: The border radius - default `0`
+  */
   --card-border-radius: #{$border-radius};
+  /**
+  * @prop --card-padding: The inner padding - default `8px`
+  */
   --card-padding: #{$spacer};
+  /**
+  * @prop --card-margin: The outer margin - default `8px`
+  */
   --card-margin: #{$spacer};
 
   article {

--- a/core/src/components/card/card.tsx
+++ b/core/src/components/card/card.tsx
@@ -1,5 +1,9 @@
 import { Component, ComponentInterface, Host, h } from "@stencil/core";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "LYZGXeP" }
+ * @docsMenu { "group": "layout", "subGroup": "card" }
+ */
 @Component({
   tag: "sen-card",
   styleUrl: "card.scss",

--- a/core/src/components/card/readme.md
+++ b/core/src/components/card/readme.md
@@ -1,16 +1,37 @@
 # sen-card
 
+<!-- Auto Generated Below -->
+
+
+## Usage
+
+### Example
+
+```html
+<sen-card>
+  <sen-card-title>
+    Card tryout title
+  </sen-card-title>
+  <sen-card-body>
+    Some card body content
+  </sen-card-body>
+  <sen-card-actions>
+    <sen-button>A button 1</sen-button>
+    <sen-button>A button 2</sen-button>
+  </sen-card-actions>
+</sen-card>
+```
+
+
 
 ## CSS Custom Properties
 
-| Name                   | Default   | Description        |
-|------------------------|-----------|--------------------|
-| `--card-border-color`  | `#DEDCDC` | outer border color |
-| `--card-border-radius` | `0`       | border radius      |
-| `--card-padding`       | `8px`     | the inner padding  |
-| `--card-margin`        | `8px`     | the outer margin   |
-
-<!-- Auto Generated Below -->
+| Name                   | Description                                |
+| ---------------------- | ------------------------------------------ |
+| `--card-border-color`  | The outer border color - default `#DEDCDC` |
+| `--card-border-radius` | The border radius - default `0`            |
+| `--card-margin`        | The outer margin - default `8px`           |
+| `--card-padding`       | The inner padding - default `8px`          |
 
 
 ----------------------------------------------

--- a/core/src/components/card/usage/example.md
+++ b/core/src/components/card/usage/example.md
@@ -1,0 +1,14 @@
+```html
+<sen-card>
+  <sen-card-title>
+    Card tryout title
+  </sen-card-title>
+  <sen-card-body>
+    Some card body content
+  </sen-card-body>
+  <sen-card-actions>
+    <sen-button>A button 1</sen-button>
+    <sen-button>A button 2</sen-button>
+  </sen-card-actions>
+</sen-card>
+```

--- a/core/src/components/form-field/form-field.tsx
+++ b/core/src/components/form-field/form-field.tsx
@@ -1,5 +1,9 @@
 import { Component, ComponentInterface, Host, Prop, h } from "@stencil/core";
 
+/**
+ * @docsCodePen { "user": "casaper", "id": "ExyPZBx" }
+ * @docsMenu { "group": "forms" }
+ */
 @Component({
   tag: "sen-form-field",
   styleUrl: "form-field.scss",

--- a/core/src/components/form-field/usage/example.md
+++ b/core/src/components/form-field/usage/example.md
@@ -1,12 +1,3 @@
-# sen-col
-
-<!-- Auto Generated Below -->
-
-
-## Usage
-
-### Example
-
 ```html
 <form>
   <sen-fieldset legend="Contact Information">
@@ -40,31 +31,3 @@
   </sen-fieldset>
 </form>
 ```
-
-
-
-## Properties
-
-| Property | Attribute | Description             | Type     | Default |
-| -------- | --------- | ----------------------- | -------- | ------- |
-| `label`  | `label`   | Label of the form field | `string` | `""`    |
-
-
-## Dependencies
-
-### Depends on
-
-- [sen-row](../row)
-- [sen-col](../col)
-
-### Graph
-```mermaid
-graph TD;
-  sen-form-field --> sen-row
-  sen-form-field --> sen-col
-  style sen-form-field fill:#f9f,stroke:#333,stroke-width:4px
-```
-
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/text/readme.md
+++ b/core/src/components/text/readme.md
@@ -5,6 +5,60 @@
 <!-- Auto Generated Below -->
 
 
+## Usage
+
+### Align
+
+```html
+<sen-text align="right">Right aligned text.</sen-text>
+<sen-text align="center">Center aligned text.</sen-text>
+<sen-text align="justify">Justify aligned text.</sen-text>
+```
+
+
+### Letter-spacing
+
+```html
+<sen-text>normal letter spacing</sen-text>
+<sen-text letter-spacing="1px">1px letter spacing</sen-text>
+```
+
+
+### Tags
+
+```html
+<sen-text>Element default is a p element</sen-text>
+<sen-text tag="p">Element p</sen-text>
+<sen-text tag="h1">Element h1</sen-text>
+<sen-text tag="h2">Element h2</sen-text>
+<sen-text tag="h3">Element h3</sen-text>
+<sen-text tag="h4">Element h4</sen-text>
+<sen-text tag="h5">Element h5</sen-text>
+<sen-text tag="h6">Element h6</sen-text>
+```
+
+
+### Text-transform
+
+```html
+<sen-text>normal Text transform</sen-text>
+<sen-text text-transform="capitalize">capitalize Text transform</sen-text>
+<sen-text text-transform="uppercase">uppercase Text transform</sen-text>
+<sen-text text-transform="lowercase">lowercase Text transform</sen-text>
+<sen-text text-transform="full-width">full-width Text transform</sen-text>
+```
+
+
+### Weight
+
+```html
+<sen-text weight="light" kind="p">Element p light</sen-text>
+<sen-text weight="regular" kind="p">Element p regular</sen-text>
+<sen-text weight="bold" kind="p">Element p bold</sen-text>
+```
+
+
+
 ## Properties
 
 | Property        | Attribute        | Description                                                                       | Type                                                                   | Default     |

--- a/core/src/components/text/usage/align.md
+++ b/core/src/components/text/usage/align.md
@@ -1,0 +1,5 @@
+```html
+<sen-text align="right">Right aligned text.</sen-text>
+<sen-text align="center">Center aligned text.</sen-text>
+<sen-text align="justify">Justify aligned text.</sen-text>
+```

--- a/core/src/components/text/usage/letter-spacing.md
+++ b/core/src/components/text/usage/letter-spacing.md
@@ -1,0 +1,4 @@
+```html
+<sen-text>normal letter spacing</sen-text>
+<sen-text letter-spacing="1px">1px letter spacing</sen-text>
+```

--- a/core/src/components/text/usage/tags.md
+++ b/core/src/components/text/usage/tags.md
@@ -1,0 +1,10 @@
+```html
+<sen-text>Element default is a p element</sen-text>
+<sen-text tag="p">Element p</sen-text>
+<sen-text tag="h1">Element h1</sen-text>
+<sen-text tag="h2">Element h2</sen-text>
+<sen-text tag="h3">Element h3</sen-text>
+<sen-text tag="h4">Element h4</sen-text>
+<sen-text tag="h5">Element h5</sen-text>
+<sen-text tag="h6">Element h6</sen-text>
+```

--- a/core/src/components/text/usage/text-transform.md
+++ b/core/src/components/text/usage/text-transform.md
@@ -1,0 +1,7 @@
+```html
+<sen-text>normal Text transform</sen-text>
+<sen-text text-transform="capitalize">capitalize Text transform</sen-text>
+<sen-text text-transform="uppercase">uppercase Text transform</sen-text>
+<sen-text text-transform="lowercase">lowercase Text transform</sen-text>
+<sen-text text-transform="full-width">full-width Text transform</sen-text>
+```

--- a/core/src/components/text/usage/weight.md
+++ b/core/src/components/text/usage/weight.md
@@ -1,0 +1,5 @@
+```html
+<sen-text weight="light" kind="p">Element p light</sen-text>
+<sen-text weight="regular" kind="p">Element p regular</sen-text>
+<sen-text weight="bold" kind="p">Element p bold</sen-text>
+```


### PR DESCRIPTION
1. added propper css custom properties comments in sen-card documentation
1. added several missing usage examples for docs
1. sen-button-group border-radius setting
1. fix sen-button-group to have round border with 1 to any number of buttons
1. add demoUrl and demoSourceUrl with custom jsdoc property to be processed by the docs builder

The demo url works allready together with the other mr in the docs repo:

![image](https://user-images.githubusercontent.com/5822656/96045196-e6ba6280-0e71-11eb-82aa-e474698a2b92.png)
